### PR TITLE
Keyboard Shortcuts and Collision Improvements

### DIFF
--- a/Collisions.h
+++ b/Collisions.h
@@ -23,15 +23,11 @@ public:
         for (auto comp : collisions) {
             glm::vec3& aPosition = Engine::GetComponent<Transform>(comp.a).position;
             glm::vec3& bPosition = Engine::GetComponent<Transform>(comp.b).position;
+            MeshCollisionBox& aBox = Engine::GetComponent<MeshCollisionBox>(comp.a);
+            MeshCollisionBox& bBox = Engine::GetComponent<MeshCollisionBox>(comp.b);
 
-            if (Engine::HasComponent<Physics>(comp.a)) {
-                Physics& aPhysics = Engine::GetComponent<Physics>(comp.a);
-                aPosition -= aPhysics.velocity * Time::deltaTime;
-            }
-            if (Engine::HasComponent<Physics>(comp.b)) {
-                Physics& bPhysics = Engine::GetComponent<Physics>(comp.b);
-                bPosition -= bPhysics.velocity * Time::deltaTime;
-            }
+            aPosition += glm::normalize(aPosition - bPosition) * ((aPosition + aBox.min) - (bPosition + bBox.max));
+            bPosition += glm::normalize(bPosition - aPosition) * ((bPosition + bBox.min) - (aPosition + aBox.max));
         }
     }
     static void CheckCollisions(std::vector<Collision>* collisions, unsigned int e, MeshCollisionBox box) {

--- a/Collisions.h
+++ b/Collisions.h
@@ -8,6 +8,8 @@ struct Collision {
 public:
     unsigned int a;
     unsigned int b;
+    MeshCollisionBox& bbA;
+    MeshCollisionBox& bbB;
 
     bool operator==(Collision rhs) {
         return a == rhs.a && b == rhs.b;
@@ -23,23 +25,30 @@ public:
         for (auto comp : collisions) {
             glm::vec3& aPosition = Engine::GetComponent<Transform>(comp.a).position;
             glm::vec3& bPosition = Engine::GetComponent<Transform>(comp.b).position;
-            MeshCollisionBox& aBox = Engine::GetComponent<MeshCollisionBox>(comp.a);
-            MeshCollisionBox& bBox = Engine::GetComponent<MeshCollisionBox>(comp.b);
 
-            aPosition += glm::normalize(aPosition - bPosition) * ((aPosition + aBox.min) - (bPosition + bBox.max));
-            bPosition += glm::normalize(bPosition - aPosition) * ((bPosition + bBox.min) - (aPosition + aBox.max));
+            if (Engine::HasComponent<Physics>(comp.a)) {
+                auto& physicsA = Engine::GetComponent<Physics>(comp.a);
+                if(!Engine::HasComponent<Physics>(comp.b) || abs(glm::length(physicsA.velocity)) > abs(glm::length(Engine::GetComponent<Physics>(comp.b).velocity)))
+                    aPosition += glm::normalize(aPosition - bPosition) * ((((aPosition + comp.bbA.min) - (bPosition + comp.bbB.max))) + glm::vec3(0.001f));
+            }
+            if (Engine::HasComponent<Physics>(comp.b)) {
+
+                auto& physicsB = Engine::GetComponent<Physics>(comp.b);
+                if (!Engine::HasComponent<Physics>(comp.a) || abs(glm::length(physicsB.velocity)) > abs(glm::length(Engine::GetComponent<Physics>(comp.a).velocity)))
+                    bPosition += glm::normalize(bPosition - aPosition) * ((((bPosition + comp.bbB.min) - (aPosition + comp.bbA.max))) + glm::vec3(0.001f));
+            }
         }
     }
-    static void CheckCollisions(std::vector<Collision>* collisions, unsigned int e, MeshCollisionBox box) {
+    static void CheckCollisions(std::vector<Collision>* collisions, unsigned int e, MeshCollisionBox& box) {
         Transform& transform = Engine::GetComponent<Transform>(e);
-        for (auto otherComp : Engine::FindComponentsInScene<MeshCollisionBox>()) {
+        for (auto& otherComp : Engine::FindComponentsInScene<MeshCollisionBox>()) {
             if (e != otherComp) {
-                auto otherTransform = Engine::GetComponent<Transform>(otherComp);
-                auto otherBoundingBox = Engine::GetComponent<MeshCollisionBox>(otherComp);
+                auto& otherTransform = Engine::GetComponent<Transform>(otherComp);
+                auto& otherBoundingBox = Engine::GetComponent<MeshCollisionBox>(otherComp);
                 if (Collides(transform.position, otherTransform.position, box, otherBoundingBox)) {
-                    if (std::find(collisions->begin(), collisions->end(), Collision{ otherComp, e }) == collisions->end()) {
+                    if (std::find(collisions->begin(), collisions->end(), Collision{ otherComp, e, box, otherBoundingBox }) == collisions->end()) {
                         Console::LogMessage("collided");
-                        collisions->push_back({ e, otherComp });
+                        collisions->push_back({ e, otherComp, box, otherBoundingBox });
                     }
                 }
             }
@@ -50,7 +59,7 @@ public:
         auto boundingBoxes = Engine::FindComponentsInScene<MeshCollisionBox>();
         std::vector<Collision> collisions;
         for (auto comp : boundingBoxes) {
-            auto boundingBox = Engine::GetComponent<MeshCollisionBox>(comp);
+            auto& boundingBox = Engine::GetComponent<MeshCollisionBox>(comp);
             CheckCollisions(&collisions, comp, boundingBox);
         }
 
@@ -62,7 +71,7 @@ public:
         b.min += positionB;
         b.max += positionB;
         return (
-            a.min.x <= b.max.x &&
+            a.min.x <=  b.max.x &&
             a.max.x >= b.min.x &&
             a.min.y <= b.max.y &&
             a.max.y >= b.min.y &&

--- a/ComponentArray.h
+++ b/ComponentArray.h
@@ -19,6 +19,7 @@ public:
 	std::unordered_map<unsigned int, T> components;
 	void Add(unsigned int entity, T component) {
 		components[entity] = component;
+		components[entity].Start();
 	}
 	void Add(unsigned int entity) {
 		T value;

--- a/ComponentArray.h
+++ b/ComponentArray.h
@@ -8,6 +8,7 @@ public:
 	virtual void Start() = 0;
 	virtual void Update(bool inRuntime) = 0;
 	virtual void Add(unsigned int entity) = 0;
+	virtual bool HasComponent(unsigned int) = 0;
 	virtual void DrawComponentGUI(unsigned int entity) = 0;
 };
 
@@ -23,6 +24,9 @@ public:
 		T value;
 		value.entity = entity;
 		components[entity] = value;
+	}
+	bool HasComponent(unsigned int entity) {
+		return components.find(entity) != components.end();
 	}
 	void Remove(unsigned int entity) {
 		components.erase(entity);

--- a/ComponentManager.h
+++ b/ComponentManager.h
@@ -36,6 +36,14 @@ public:
 			componentArrays[compArr.first]->Update(inRuntime);
 		}
 	}
+	std::vector<std::string> GetEntityComponents(unsigned int entity) {
+		std::vector<std::string> comps;
+		for (auto comp : componentArrays) {
+			if (comp.second->HasComponent(entity))
+				comps.push_back(comp.first);
+		}
+		return comps;
+	}
 	void DrawEntityComponentGUI(unsigned int entity) {
 		for (auto comp : componentArrays) {
 			componentArrays[comp.first]->DrawComponentGUI(entity);

--- a/Engine.h
+++ b/Engine.h
@@ -21,6 +21,9 @@ public:
 		return entity;
 	}
 	static void DestroyEntity(unsigned int entity) {
+		auto entPos = std::find(SceneManager::activeScene.entities.begin(), SceneManager::activeScene.entities.end(), entity);
+		if (entPos != SceneManager::activeScene.entities.end())
+			SceneManager::activeScene.entities.erase(entPos);
 		entityManager.DestroyEntity(entity);
 		componentManager.OnEntityDestroyed(entity);
 	}
@@ -74,6 +77,9 @@ public:
 	}
 	static std::vector<std::string> GetRegisteredComponents() {
 		return componentManager.GetRegisteredComponents();
+	}
+	static std::vector<std::string> GetEntityComponents(unsigned int entity) {
+		return componentManager.GetEntityComponents(entity);
 	}
 	template<class T>
 	static void RemoveComponent(unsigned int entity) {

--- a/Main.cpp
+++ b/Main.cpp
@@ -89,8 +89,18 @@ void ProcessInput(GLFWwindow* window, int key, int scancode, int action, int mod
 			else
 				InputManager::SetMouseLocked();
 		}
-		if (key == GLFW_KEY_F1)
-			Console::LogMessage("test message");
+		if (key == GLFW_KEY_F1) {
+			auto a = Engine::CreateEntity();
+			Engine::AddComponent<MeshRenderer>(a, MeshRenderer());
+			Engine::AddComponent<Physics>(a, Physics());
+			Engine::AddComponent<MeshCollisionBox>(a, MeshCollisionBox());
+			auto& transform = Engine::GetComponent<Transform>(a);
+			transform.position.y = 5.0f;
+
+			auto b = Engine::CreateEntity();
+			Engine::AddComponent<MeshRenderer>(b, MeshRenderer());
+			Engine::AddComponent<MeshCollisionBox>(b, MeshCollisionBox());
+		}
 		if (key == GLFW_KEY_F4)
 			Console::LogError("test error");
 		if (key == GLFW_KEY_F3) {

--- a/Main.cpp
+++ b/Main.cpp
@@ -75,6 +75,9 @@ float runtimeStartTime = 0.0f;
 View sceneView;
 View gameView;
 View* activeView = &sceneView;
+int selectedEntity = -1;
+int clipboardEntity = -1;
+
 void ProcessInput(GLFWwindow* window, int key, int scancode, int action, int mods) {
 	ImGui_ImplGlfw_KeyCallback(window, key, scancode, action, mods);
 	if (action == GLFW_PRESS) {
@@ -94,6 +97,22 @@ void ProcessInput(GLFWwindow* window, int key, int scancode, int action, int mod
 			Scripting::OnRuntimeStart();
 			inRuntime = true;
 			runtimeStartTime = glfwGetTime();
+		}
+
+		if (key == GLFW_KEY_D && mods == GLFW_MOD_CONTROL && selectedEntity > -1 ) {
+			unsigned int newEntity = Engine::CreateEntity();
+			for (auto& script : Engine::GetEntityScripts(selectedEntity)) {
+				Engine::AddScript(newEntity, script);
+				Scripting::LoadEntityScript(newEntity, script);
+			}
+			for (auto& comp : Engine::GetEntityComponents(selectedEntity)) {
+				Engine::AddComponent(newEntity, comp);
+			}
+		}
+		if (key == GLFW_KEY_DELETE && selectedEntity > -1) {
+			Engine::DestroyEntity(selectedEntity);
+			Scripting::OnEntityDestroyed(selectedEntity);
+			selectedEntity = -1;
 		}
 	}
 }
@@ -198,7 +217,6 @@ int main() {
 	Shaders::activeShader = Shader(defaultVertexSource, defaultFragmentSource);
 	Shaders::activeShader.Use();
 	Engine::Start();
-	unsigned int selectedEntity = -1;
 	glfwSetKeyCallback(window, ProcessInput);
 	glfwSetCursorPosCallback(window, HandleMouseInput);
 

--- a/Physics.h
+++ b/Physics.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Component.h"
 #include "Time.h"
+#include "Raycast.h"
 #include <glm/glm.hpp>
 class Physics : public Component {
 public:
@@ -10,6 +11,7 @@ public:
 	float gravity = 9.8f;
 	bool useDrag = true;
 	float drag = 9.0f;
+	bool isGrounded;
 
 	static void DrawGUI(unsigned int selectedEntity) {
 		if (Engine::HasComponent<Physics>(selectedEntity)) {
@@ -48,14 +50,23 @@ public:
 		if (inRuntime) {
 			if (useDrag)
 				ApplyDrag();
-			if (useGravity)
+			if (useGravity && !isGrounded)
 				ApplyGravity();
 
 			if (velocity.y < -20.0f)
 				velocity.y = -20.0f;
 
-			Transform& position = Engine::GetComponent<Transform>(entity);
-			position.position += velocity * Time::deltaTime;
+			auto& transform = Engine::GetComponent<Transform>(entity);
+			auto& boundingBox = Engine::GetComponent<MeshCollisionBox>(entity);
+			std::vector<unsigned int> outHits;
+			isGrounded = Raycast(transform.position, glm::vec3(0.0f, -1.0f, 0.0f), abs(boundingBox.min.y) + 0.3f, &outHits, entity);
+			if (isGrounded && velocity.y < 0.0f) {
+				velocity.y = 0.0f;
+				std::cout << "grounded" << std::endl;
+			}
+			transform.position += velocity * Time::deltaTime;
+
+
 		}
 	}
 

--- a/Raycast.h
+++ b/Raycast.h
@@ -7,9 +7,12 @@
 struct Ray {
 	glm::vec3 origin;
 	glm::vec3 direction;
+	float distance;
 };
 
 bool IntersectsCollider(const Ray& ray, const MeshCollisionBox& collider) {
+	if (glm::distance(ray.origin, Engine::GetComponent<Transform>(collider.entity).position) > ray.distance)
+		return false;
 	float intersectMinX = (collider.min.x - ray.origin.x) / ray.direction.x;
 	float intersectMaxX = (collider.max.x - ray.origin.x) / ray.direction.x;
 
@@ -53,10 +56,9 @@ bool IntersectsCollider(const Ray& ray, const MeshCollisionBox& collider) {
 
 }
 
-bool CheckCollision(Ray& ray, std::vector<unsigned int>* outHit) {
+bool CheckCollision(Ray& ray, std::vector<unsigned int>* outHit, int excludeEntity) {
 	for (auto collider : Engine::FindComponentsInScene<MeshCollisionBox>()) {
-		if (IntersectsCollider(ray, Engine::GetComponent<MeshCollisionBox>(collider))) {
-			Console::LogMessage("collided");
+		if (IntersectsCollider(ray, Engine::GetComponent<MeshCollisionBox>(collider)) && collider != excludeEntity) {
 			outHit->push_back(collider);
 		}
 	}
@@ -64,7 +66,7 @@ bool CheckCollision(Ray& ray, std::vector<unsigned int>* outHit) {
 }
 
 
-bool Raycast(glm::vec3 origin, glm::vec3 direction, float distance, std::vector<unsigned int>* outHits = nullptr) {
-	Ray ray = { origin, direction };
-	return CheckCollision(ray, outHits);
+bool Raycast(glm::vec3 origin, glm::vec3 direction, float distance, std::vector<unsigned int>* outHits = nullptr, int excludeEntity = -1) {
+	Ray ray = { origin, direction, distance };
+	return CheckCollision(ray, outHits, excludeEntity);
 }

--- a/Scripting.h
+++ b/Scripting.h
@@ -181,6 +181,10 @@ public:
 	static bool GetKeyDown(int key) {
 		return InputManager::GetKeyDown(key);
 	}
+	static void OnEntityDestroyed(unsigned int entity) {
+		if (data.entities.find(entity) != data.entities.end())
+			data.entities.erase(entity);
+	}
 	static MonoArray* FindComponentsInScene(MonoString* name) {
 		std::vector<unsigned int> entities = Engine::FindScriptInScene(mono_string_to_utf8(name));
 		MonoArray* arr = mono_array_new(mono_get_root_domain(), mono_get_uint32_class(), entities.size());


### PR DESCRIPTION
* Added ctrl + d to duplicate an entity and it's components.
* Added the delete key to delete entities in the editor
* Once again improved collision resolutions.